### PR TITLE
Independent EventuateRedisTemplate configuration to avoid conflicts with Spring's RedisAutoConfiguration

### DIFF
--- a/eventuate-messaging-redis-spring-common/build.gradle
+++ b/eventuate-messaging-redis-spring-common/build.gradle
@@ -4,7 +4,7 @@ dependencies {
 
     api 'org.springframework.data:spring-data-redis:2.6.6'
     api 'io.lettuce:lettuce-core:6.1.9.RELEASE'
-    api 'org.redisson:redisson:3.10.3'
+    api 'org.redisson:redisson:3.22.0'
     api 'org.apache.commons:commons-lang3:3.12.0'
     testImplementation 'com.google.guava:guava:19.0'
     testImplementation "io.eventuate.util:eventuate-util-test:$eventuateUtilVersion"

--- a/eventuate-messaging-redis-spring-common/src/main/java/io/eventuate/messaging/redis/spring/common/CommonRedisConfiguration.java
+++ b/eventuate-messaging-redis-spring-common/src/main/java/io/eventuate/messaging/redis/spring/common/CommonRedisConfiguration.java
@@ -3,7 +3,6 @@ package io.eventuate.messaging.redis.spring.common;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
-import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 @Configuration
@@ -19,17 +18,19 @@ public class CommonRedisConfiguration {
     return new RedisServers(redisConfigurationProperties.getServers());
   }
 
-  @Bean
+  // @Bean Avoid conflicts with org.springframework.boot.autoconfigure.data.redis.RedisAutoConfiguration.
   public LettuceConnectionFactory lettuceConnectionFactory(RedisServers redisServers) {
     RedisServers.HostAndPort mainServer = redisServers.getHostsAndPorts().get(0);
-    return new LettuceConnectionFactory(mainServer.getHost(), mainServer.getPort());
+    LettuceConnectionFactory factory = new LettuceConnectionFactory( mainServer.getHost( ), mainServer.getPort( ) );
+    factory.afterPropertiesSet();
+    return factory;
   }
 
   @Bean
-  public RedisTemplate<String, String> redisTemplate(LettuceConnectionFactory lettuceConnectionFactory) {
+  public EventuateRedisTemplate eventuateRedisTemplate( RedisServers redisServers) {
     StringRedisSerializer stringRedisSerializer = new StringRedisSerializer();
-    RedisTemplate<String, String> template = new RedisTemplate<>();
-    template.setConnectionFactory(lettuceConnectionFactory);
+    EventuateRedisTemplate template = new EventuateRedisTemplate();
+    template.setConnectionFactory(lettuceConnectionFactory(redisServers));
     template.setDefaultSerializer(stringRedisSerializer);
     template.setKeySerializer(stringRedisSerializer);
     template.setValueSerializer(stringRedisSerializer);

--- a/eventuate-messaging-redis-spring-common/src/main/java/io/eventuate/messaging/redis/spring/common/EventuateRedisTemplate.java
+++ b/eventuate-messaging-redis-spring-common/src/main/java/io/eventuate/messaging/redis/spring/common/EventuateRedisTemplate.java
@@ -1,0 +1,6 @@
+package io.eventuate.messaging.redis.spring.common;
+
+import org.springframework.data.redis.core.RedisTemplate;
+
+public class EventuateRedisTemplate extends RedisTemplate<String, String> {
+}

--- a/eventuate-messaging-redis-spring-consumer/src/main/java/io/eventuate/messaging/redis/spring/consumer/MessageConsumerRedisConfiguration.java
+++ b/eventuate-messaging-redis-spring-consumer/src/main/java/io/eventuate/messaging/redis/spring/consumer/MessageConsumerRedisConfiguration.java
@@ -4,21 +4,21 @@ import io.eventuate.coordination.leadership.LeaderSelectorFactory;
 import io.eventuate.messaging.partitionmanagement.*;
 import io.eventuate.messaging.redis.spring.common.CommonRedisConfiguration;
 import io.eventuate.messaging.redis.spring.common.RedisConfigurationProperties;
+import io.eventuate.messaging.redis.spring.common.EventuateRedisTemplate;
 import io.eventuate.messaging.redis.spring.common.RedissonClients;
 import io.eventuate.messaging.redis.spring.leadership.RedisLeaderSelector;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
-import org.springframework.data.redis.core.RedisTemplate;
 
 @Configuration
 @Import(CommonRedisConfiguration.class)
 public class MessageConsumerRedisConfiguration {
 
   @Bean
-  public MessageConsumerRedisImpl messageConsumerRedis(RedisTemplate<String, String> redisTemplate,
-                                         CoordinatorFactory coordinatorFactory,
-                                         RedisConfigurationProperties redisConfigurationProperties) {
+  public MessageConsumerRedisImpl messageConsumerRedis(EventuateRedisTemplate redisTemplate,
+                                                       CoordinatorFactory coordinatorFactory,
+                                                       RedisConfigurationProperties redisConfigurationProperties) {
 
     return new MessageConsumerRedisImpl(redisTemplate,
             coordinatorFactory,
@@ -42,7 +42,7 @@ public class MessageConsumerRedisConfiguration {
   }
 
   @Bean
-  public GroupMemberFactory groupMemberFactory(RedisTemplate<String, String> redisTemplate,
+  public GroupMemberFactory groupMemberFactory(EventuateRedisTemplate redisTemplate,
                                                RedisConfigurationProperties redisConfigurationProperties) {
     return (groupId, memberId) ->
             new RedisGroupMember(redisTemplate,
@@ -64,7 +64,7 @@ public class MessageConsumerRedisConfiguration {
   }
 
   @Bean
-  public MemberGroupManagerFactory memberGroupManagerFactory(RedisTemplate<String, String> redisTemplate,
+  public MemberGroupManagerFactory memberGroupManagerFactory(EventuateRedisTemplate redisTemplate,
                                                              RedisConfigurationProperties redisConfigurationProperties) {
     return (groupId, memberId, groupMembersUpdatedCallback) ->
             new RedisMemberGroupManager(redisTemplate,
@@ -75,7 +75,7 @@ public class MessageConsumerRedisConfiguration {
   }
 
   @Bean
-  public AssignmentListenerFactory assignmentListenerFactory(RedisTemplate<String, String> redisTemplate,
+  public AssignmentListenerFactory assignmentListenerFactory(EventuateRedisTemplate redisTemplate,
                                                              RedisConfigurationProperties redisConfigurationProperties) {
     return (groupId, memberId, assignmentUpdatedCallback) ->
             new RedisAssignmentListener(redisTemplate,
@@ -86,7 +86,7 @@ public class MessageConsumerRedisConfiguration {
   }
 
   @Bean
-  public AssignmentManager assignmentManager(RedisTemplate<String, String> redisTemplate,
+  public AssignmentManager assignmentManager(EventuateRedisTemplate redisTemplate,
                                              RedisConfigurationProperties redisConfigurationProperties) {
     return new RedisAssignmentManager(redisTemplate, redisConfigurationProperties.getAssignmentTtlInMilliseconds());
   }

--- a/eventuate-messaging-redis-spring-consumer/src/test/java/io/eventuate/messaging/redis/spring/consumer/AssignmentManagingTest.java
+++ b/eventuate-messaging-redis-spring-consumer/src/test/java/io/eventuate/messaging/redis/spring/consumer/AssignmentManagingTest.java
@@ -2,13 +2,13 @@ package io.eventuate.messaging.redis.spring.consumer;
 
 import io.eventuate.messaging.partitionmanagement.Assignment;
 import io.eventuate.messaging.redis.spring.common.CommonRedisConfiguration;
+import io.eventuate.messaging.redis.spring.common.EventuateRedisTemplate;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.test.context.junit4.SpringRunner;
 
 import java.util.*;
@@ -18,7 +18,7 @@ import java.util.*;
 public class AssignmentManagingTest {
 
   @Autowired
-  private RedisTemplate<String, String> redisTemplate;
+  private EventuateRedisTemplate redisTemplate;
 
   private String groupId;
   private String memberId;

--- a/eventuate-messaging-redis-spring-consumer/src/test/java/io/eventuate/messaging/redis/spring/consumer/GroupManagingTest.java
+++ b/eventuate-messaging-redis-spring-consumer/src/test/java/io/eventuate/messaging/redis/spring/consumer/GroupManagingTest.java
@@ -1,6 +1,7 @@
 package io.eventuate.messaging.redis.spring.consumer;
 
 import io.eventuate.messaging.redis.spring.common.CommonRedisConfiguration;
+import io.eventuate.messaging.redis.spring.common.EventuateRedisTemplate;
 import io.eventuate.util.test.async.Eventually;
 import org.junit.Assert;
 import org.junit.Before;
@@ -8,7 +9,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.test.context.junit4.SpringRunner;
 
 import java.util.Collections;
@@ -21,7 +21,7 @@ import java.util.UUID;
 public class GroupManagingTest {
 
   @Autowired
-  private RedisTemplate<String, String> redisTemplate;
+  private EventuateRedisTemplate redisTemplate;
 
   private String groupId;
   private String memberId;

--- a/eventuate-messaging-redis-spring-consumer/src/test/java/io/eventuate/messaging/redis/spring/consumer/MessageConsumerRedisImplTest.java
+++ b/eventuate-messaging-redis-spring-consumer/src/test/java/io/eventuate/messaging/redis/spring/consumer/MessageConsumerRedisImplTest.java
@@ -1,5 +1,6 @@
 package io.eventuate.messaging.redis.spring.consumer;
 
+import io.eventuate.messaging.redis.spring.common.EventuateRedisTemplate;
 import io.eventuate.messaging.redis.spring.common.RedisConfigurationProperties;
 import io.eventuate.messaging.redis.spring.common.RedisUtil;
 import io.eventuate.util.test.async.Eventually;
@@ -10,7 +11,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.redis.connection.stream.ReadOffset;
 import org.springframework.data.redis.connection.stream.StreamRecords;
-import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.test.context.junit4.SpringRunner;
 
 import java.util.ArrayList;
@@ -23,7 +23,7 @@ import java.util.concurrent.TimeUnit;
 public class MessageConsumerRedisImplTest {
 
   @Autowired
-  private RedisTemplate<String, String> redisTemplate;
+  private EventuateRedisTemplate redisTemplate;
 
   @Autowired
   private RedisConfigurationProperties redisConfigurationProperties;

--- a/eventuate-messaging-redis-spring-integration-tests/src/test/java/io/eventuate/messaging/redis/spring/integrationtests/MessagingTest.java
+++ b/eventuate-messaging-redis-spring-integration-tests/src/test/java/io/eventuate/messaging/redis/spring/integrationtests/MessagingTest.java
@@ -4,6 +4,7 @@ import io.eventuate.messaging.partitionmanagement.CoordinatorFactory;
 import io.eventuate.messaging.partitionmanagement.CoordinatorFactoryImpl;
 import io.eventuate.messaging.partitionmanagement.tests.AbstractMessagingTest;
 import io.eventuate.messaging.redis.spring.common.CommonRedisConfiguration;
+import io.eventuate.messaging.redis.spring.common.EventuateRedisTemplate;
 import io.eventuate.messaging.redis.spring.common.RedissonClients;
 import io.eventuate.messaging.redis.spring.leadership.RedisLeaderSelector;
 import io.eventuate.messaging.redis.spring.producer.EventuateRedisProducer;
@@ -14,7 +15,6 @@ import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
-import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit4.SpringRunner;
 
@@ -33,7 +33,7 @@ public class MessagingTest extends AbstractMessagingTest {
   }
 
   @Autowired
-  private RedisTemplate<String, String> redisTemplate;
+  private EventuateRedisTemplate redisTemplate;
 
   @Autowired
   private RedissonClients redissonClients;


### PR DESCRIPTION
- Independent EventuateRedisTemplate configuration to avoid conflicts with Spring's RedisAutoConfiguration
- Upgrade Redisson:3.22.0 to resolve JDK module errors.
- [build-and-test-all.sh.log](https://github.com/user-attachments/files/19844447/build-and-test-all.sh.log)
